### PR TITLE
Descriptions in tickets

### DIFF
--- a/src/jira.coffee
+++ b/src/jira.coffee
@@ -9,7 +9,7 @@
 #   HUBOT_JIRA_URL (format: "https://jira-domain.com:9090")
 #   HUBOT_JIRA_USERNAME
 #   HUBOT_JIRA_PASSWORD
-#   HUBOT_JIRA_PROJECTS_MAP (format: {\"web\":\"WEB\",\"android\":\"AN\",\"ios\":\"IOS\",\"platform\":\"PLAT\"}
+#   HUBOT_JIRA_PROJECTS_MAP (format: "{\"web\":\"WEB\",\"android\":\"AN\",\"ios\":\"IOS\",\"platform\":\"PLAT\"}"
 #
 # Commands:
 #   hubot bug - File a bug in JIRA corresponding to the project of the channel
@@ -42,13 +42,16 @@ module.exports = (robot) ->
               user = JSON.parse body
               reporter = user[0] if user and user.length is 1
             finally
+              desc = msg.match(/"(.*?)"/)[1] if /"(.*?)"/.test(msg)
+              msg = msg.replace(/"(.*?)"/,"") if desc != undefined
               issue =
                 fields:
                   project:
                     key: project
                   summary: msg.match[1]
                   labels: ["triage"]
-                  description: """
+                  description: (if desc != undefined then (desc + "\n") else "") +
+                               """
                                Reported by #{msg.message.user.name} in ##{msg.message.room} on #{robot.adapterName}
                                https://#{robot.adapter.client.team.domain}.slack.com/archives/#{msg.message.room}/p#{msg.message.id.replace '.', ''}
                                """


### PR DESCRIPTION
I think this will work but I haven't tested it using hal. It lets you specify a description such as

hal bug Reading events missing info "A small portion of reading events (start/stop) are missing everything but the event name on android"

I know that the best practice would be to only set the name of the ticket using hal and then manually add the description, labels, etc using the link provided, but I've noticed a lot of people tend to throw in what amounts to a description in the title when rushing to create tickets, such as during regression testing. This ensures those people have one less excuse