### PR TITLE
META-52: Implemented JIRA Webhook integration

### DIFF
--- a/src/adapters/generic.coffee
+++ b/src/adapters/generic.coffee
@@ -1,7 +1,22 @@
 _ = require "underscore"
 
+Utils = require "../utils"
+
 class GenericAdapter
   constructor: (@robot) ->
+    @disabledUsers = null
+    @robot.brain.once "loaded", =>
+      @disabledUsers = @robot.brain.get("jira-notifications-disabled") or []
+
+  disableNotificationsFor: (user) ->
+    @robot.logger.info "Disabling JIRA notifications for #{user.name}"
+    @disabledUsers.push user.id
+    @robot.brain.set "jira-notifications-disabled", @disabledUsers
+
+  enableNotificationsFor: (user) ->
+    @robot.logger.info "Enabling JIRA notifications for #{user.name}"
+    @disabledUsers = _(@disabledUsers).without user.id
+    @robot.brain.set "jira-notifications-disabled", @disabledUsers
 
   send: (context, message) ->
     if _(message).isString()
@@ -15,5 +30,15 @@ class GenericAdapter
       return @robot.logger.error "Unable to find a message to send", message
 
     @robot.send room: context.message.room, payload
+
+  dm: (jiraUsers, message) ->
+    for jiraUser in jiraUsers
+      user = Utils.lookupChatUserWithJira jiraUser
+      if user and not _(@disabledUsers).contains user.id
+        @send message: room: user.name, message
+      else if not user
+        @robot.logger.error "Unable to find chat user from jira #{jira}"
+      else
+        @robot.logger.info "JIRA Notification surpressed for #{user.name}"
 
 module.exports = GenericAdapter

--- a/src/adapters/slack.coffee
+++ b/src/adapters/slack.coffee
@@ -3,9 +3,11 @@ _ = require "underscore"
 Config = require "../config"
 Jira = require "../jira"
 Utils = require "../utils"
+GenericAdapter = require "./generic"
 
-class Slack
+class Slack extends GenericAdapter
   constructor: (@robot) ->
+    super @robot
     # Since the slack client used by hubot-slack has not yet been updated
     # to the latest version, we do not get events for reactions.
     # Also there doesn't seem to be a better way to get a reference to

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -55,6 +55,7 @@ class Config
     regex: eval "/(?\:^|\\s)((?\:#{Config.projects.prefixes}-)(?\:\\d+)) rank (.*)/i"
 
   @watch:
+    notificationsRegex: /jira (allow|start|enable|disallow|disable|stop)( notifications)?/i
     regex: eval "/(?\:^|\\s)((?\:#{Config.projects.prefixes}-)(?\:\\d+)) (un)?watch(?: @?([\\w._]*))?/i"
 
   @assign:

--- a/src/help.coffee
+++ b/src/help.coffee
@@ -78,6 +78,23 @@ class Help
     the watcher on the ticket, if omitted the message author will become the watcher
     """
 
+    notifications = """
+    *Ticket Notifications*
+
+    Whenever you begin watching a JIRA ticket you will be notified (via a direct
+    message from <@#{robot.adapter.self.id}>) whenever any of the following events occur:
+          - a comment is left on the ticket
+          - the ticket is in progress
+          - the ticket is resolved
+    To enable or disable this feature you can send the following directly to #{robot.name}:
+
+    > jira disable notifications
+
+    or if you wish to re-enable
+
+    > jira enable notifications
+    """
+
     search = """
     *Searching Tickets*
     > #{robot.name} jira search `<term>`
@@ -100,10 +117,10 @@ class Help
       responses = [ transition ]
     else if _(["search", "searching"]).contains topic
       responses = [ search ]
-    else if _(["watch", "watching"]).contains topic
-      responses = [ watch ]
+    else if _(["watch", "watching", "notifications", "notify"]).contains topic
+      responses = [ watch, notifications ]
     else
-      responses = [ overview, opening, rank, comment, assignment, transition, watch, search ]
+      responses = [ overview, opening, rank, comment, assignment, transition, watch, notifications, search ]
 
     return "\n#{responses.join '\n\n\n'}"
 

--- a/src/jira/index.coffee
+++ b/src/jira/index.coffee
@@ -7,6 +7,7 @@ Ticket = require "./ticket"
 Transition = require "./transition"
 User = require "./user"
 Watch = require "./watch"
+Webhook = require "./webhook"
 
 module.exports = {
   Assign
@@ -18,4 +19,5 @@ module.exports = {
   Transition
   User
   Watch
+  Webhook
 }

--- a/src/jira/webhook.coffee
+++ b/src/jira/webhook.coffee
@@ -1,0 +1,48 @@
+Utils = require "../utils"
+
+class Webhook
+  constructor: (@robot) ->
+    @robot.router.post "/hubot/jira-events", (req, res) =>
+      return unless req.body?
+      event = req.body
+      return unless event.issue.fields.watches.watchCount > 0
+
+      if event.comment?
+        return @onComment event
+      else if event.changelog?
+        return @onChangelog event
+
+  statusChangeType: (status) ->
+    acceptedTypes = [
+      keywords: "done completed resolved fixed"
+      name: "JiraWebhookTicketDone"
+    ,
+      keywords: "progress"
+      name: "JiraWebhookTicketInProgress"
+    ]
+    return Utils.fuzzyFind status, acceptedTypes, ['keywords']
+
+  onChangelog: (event) ->
+    return unless event.changelog.items?.length > 0
+
+    for item in event.changelog.items
+      continue unless item.field is "status"
+      status = @statusChangeType item.toString.toLowerCase()
+      unless status
+        @robot.logger.info "#{event.issue.key}: Ignoring transition to '#{item.toString}'"
+        continue
+
+      Create = require "./create"
+      Create.fromKey(event.issue.key)
+      .then (ticket) =>
+        @robot.logger.info "#{event.issue.key}: Emitting #{status.name} because of the transition to '#{item.toString}'"
+        @robot.emit status.name, ticket
+
+  onComment: (event) ->
+    Create = require "./create"
+    Create.fromKey(event.issue.key)
+    .then (ticket) =>
+      @robot.emit "JiraWebhookTicketComment", ticket, event.comment
+
+
+module.exports = Webhook

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -48,6 +48,12 @@ class Utils
     else
       return "Unassigned"
 
+  @lookupChatUserWithJira: (jira) ->
+    users = Utils.robot.brain.users()
+    result = (users[user] for user of users when users[user].email_address is jira.emailAddress) if jira
+    return result[0] if result?.length is 1
+    return null
+
   @lookupUserWithGithub: (github) ->
     return if not github
 
@@ -73,7 +79,7 @@ class Utils
     "?#{("#{encodeURIComponent k}=#{encodeURIComponent v}" for k,v of params when v).join "&"}"
 
   @fuzzyFind: (term, arr, keys) ->
-    f = new Fuse arr, keys: keys, shouldSort: yes
+    f = new Fuse arr, keys: keys, shouldSort: yes, threshold: 0.3
     results = f.search term
     result = if results? and results.length >=1 then results[0]
 


### PR DESCRIPTION
- Listens for webhook POSTs on `/hubot/jira-events`
- Emits an event when ticket is completed
- Emits an event when the ticket is in progress
- Emits an event when a comment is left on a ticket
- Sends a direct message to any users watching the ticket if any of the above mentioned events occur
- Support for disabling notifications for watched tickets per user