### PR TITLE
META-64 and META-65: Provide context for mentions and do not notify f…

### DIFF
--- a/src/adapters/generic.coffee
+++ b/src/adapters/generic.coffee
@@ -60,6 +60,9 @@ class GenericAdapter
       if _(@disabledUsers).contains user.id
         @robot.logger.info "JIRA Notification surpressed for #{user.name}"
       else
+        if message.author? and user.email_address is message.author.emailAddress
+          @robot.logger.info "JIRA Notification surpressed for #{user.name} because it would be a self-notification"
+          continue
         message.text += "\n#{message.footer}" if message.text and message.footer and @getDMCountFor(user) < 3
         @send message: room: user.name, message
         @incrementDMCountFor user

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -96,7 +96,7 @@ class JiraBot
       If you wish to stop receiving notifications for the tickets you are watching, reply with:
       > jira disable notifications
     """
-    @robot.on "JiraWebhookTicketInProgress", (ticket) =>
+    @robot.on "JiraWebhookTicketInProgress", (ticket, event) =>
       assignee = Utils.lookupUserWithJira ticket.fields.assignee
       assigneeText = "."
       assigneeText = " by #{assignee}" if assignee isnt "Unassigned"
@@ -105,14 +105,16 @@ class JiraBot
         text: """
           A ticket you are watching is now being worked on#{assigneeText}
         """
+        author: event.user
         footer: disableDisclaimer
         attachments: [ ticket.toAttachment no ]
 
-    @robot.on "JiraWebhookTicketDone", (ticket) =>
+    @robot.on "JiraWebhookTicketDone", (ticket, event) =>
       @adapter.dm Utils.lookupChatUsersWithJira(ticket.watchers),
         text: """
           A ticket you are watching has been marked `Done`.
         """
+        author: event.user
         footer: disableDisclaimer
         attachments: [ ticket.toAttachment no ]
 
@@ -124,15 +126,20 @@ class JiraBot
           #{comment.body}
           ```
         """
+        author: comment.author
         footer: disableDisclaimer
         attachments: [ ticket.toAttachment no ]
 
     # Mentions
-    @robot.on "JiraWebhookTicketMention", (ticket, user, event) =>
+    @robot.on "JiraWebhookTicketMention", (ticket, user, event, context) =>
       @adapter.dm user,
         text: """
           You were mentioned in a ticket by #{event.user.displayName}:
+          ```
+          #{context}
+          ```
         """
+        author: event.user
         footer: disableDisclaimer
         attachments: [ ticket.toAttachment no ]
 


### PR DESCRIPTION
…or your own activity

* When actions are performed via hubot they are performed as the the user credentials provided, thus the self check doesn't work when the action originates from the hubot.

Tracking https://jira.atlassian.com/browse/JRA-35124 to see if it gets resolved.

Also for non-cloud setups this might be a good option: https://marketplace.atlassian.com/plugins/com.jirasudo.jira-sudo/server/overview