### PR TITLE
HUBOT_JIRA_GITHUB_DISABLED

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ assigned to a ticket. Also, notifications for assignments, mentions and watched 
 - `HUBOT_JIRA_PRIORITIES_MAP` `[{"name":"Blocker","id":"1"},{"name":"Critical","id":"2"},{"name":"Major","id":"3"},{"name":"Minor","id":"4"},{"name":"Trivial","id":"5"}]`
 - `HUBOT_GITHUB_TOKEN` - Github Application Token
 - `HUBOT_GITHUB_ORG` - Github Organization or Github User
+- `HUBOT_JIRA_GITHUB_DISABLED` - Set to 'true' if you don't want to search github, and only use JIRA
 
 Note that `HUBOT_JIRA_USERNAME` should be the JIRA username, this is
 not necessarily the username used if you log in via the web.  To

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -21,9 +21,13 @@
 #   HUBOT_JIRA_PRIORITIES_MAP [{"name":"Blocker","id":"1"},{"name":"Critical","id":"2"},{"name":"Major","id":"3"},{"name":"Minor","id":"4"},{"name":"Trivial","id":"5"}]
 #   HUBOT_GITHUB_TOKEN - Github Application Token
 #   HUBOT_GITHUB_ORG - Github Organization or Github User
-#
+#   HUBOT_JIRA_GITHUB_DISABLED - Set to 'true' if you don't want to search github, and only use JIRA
+
 # Author:
 #   ndaversa
+
+# Contributions:
+#   sjakubowski
 
 _ = require "underscore"
 moment = require "moment"
@@ -102,11 +106,14 @@ class JiraBot
         _attachments.push ticket.toAttachment()
         ticket
       .then (ticket) ->
-        Github.PullRequests.fromKey ticket.key
+        if(!process.env.HUBOT_JIRA_GITHUB_DISABLED?)
+          Github.PullRequests.fromKey ticket.key
       .then (prs) ->
-        prs.toAttachment()
+        if(prs?)
+          prs.toAttachment()
       .then (attachments) ->
-        _attachments.push a for a in attachments
+        if(attachments?)
+          _attachments.push a for a in attachments
         _attachments
     ).then (attachments) =>
       @send msg, attachments: _(attachments).flatten()


### PR DESCRIPTION
Adding `HUBOT_JIRA_GITHUB_DISABLED` as an optional param to turn of github searching functionality.

Sorry @ndaversa I am not a _coffeescript_ guy so if my syntax is terrible, or there is a one liner change that works better, please let me know.

Thank you for writing the jira adapter. 