### PR TITLE
Fix transition bug due to 204 missing Content-Length

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -30,6 +30,8 @@ class Utils
         throw error
     .then (response) ->
       length = response.headers.get 'content-length'
+      if response.status is 204
+        length = 0
       response.json() unless length is "0" or length is 0
     .catch (error) ->
       Utils.robot.logger.error error


### PR DESCRIPTION
When transitioning tickets using `id > status` JIRA can return a 204
with no Content-Length header value. This change treats 204 as
implicitly having Content-Length: 0 even if it's missing.