### PR TITLE
Filter out notifications on Jira issues where comment author is watcher/assignee

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -155,7 +155,8 @@ class JiraBot
 
     # Comment notifications for watchers
     @robot.on "JiraWebhookTicketComment", (ticket, comment) =>
-      @adapter.dm Utils.lookupChatUsersWithJira(ticket.watchers),
+      watchers = (watcher for watcher in ticket.watchers when watcher.name isnt comment.author.name)
+      @adapter.dm Utils.lookupChatUsersWithJira(watchers),
         text: """
           A ticket you are watching has a new comment from #{comment.author.displayName}:
           ```
@@ -171,6 +172,7 @@ class JiraBot
     @robot.on "JiraWebhookTicketComment", (ticket, comment) =>
       return unless ticket.fields.assignee
       return if ticket.watchers.length > 0 and _(ticket.watchers).findWhere name: ticket.fields.assignee.name
+      return if ticket.fields.assignee.name is comment.author.name
 
       @adapter.dm Utils.lookupChatUsersWithJira(ticket.fields.assignee),
         text: """


### PR DESCRIPTION
Currently, a user receives a notification if they comment on a ticket that they are assigned on or watching.  This is unnecessary noise, so I forked and modified the code so that users don't get notified for their own comments.

This code is currently working for us with slack+hubot.