### PR TITLE
adding 'query' keyword for JQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ assigned to a ticket. Also, notifications for assignments, mentions and watched 
 - `HUBOT_GITHUB_ORG` - Github Organization or Github User
 - `HUBOT_GITHUB_TOKEN` - Github Application Token
 - `HUBOT_JIRA_GITHUB_DISABLED` - Set to true if you wish to disable github integration
+- `HUBOT_JIRA_MENTIONS_DISABLED` - Set to true if you wish to disable posting tickets in response to mentions in normal messages
 - `HUBOT_JIRA_PASSWORD`
 - `HUBOT_JIRA_PRIORITIES_MAP` `[{"name":"Blocker","id":"1"},{"name":"Critical","id":"2"},{"name":"Major","id":"3"},{"name":"Minor","id":"4"},{"name":"Trivial","id":"5"}]`
 - `HUBOT_JIRA_PROJECTS_MAP`  `{"web":"WEB","android":"AN","ios":"IOS","platform":"PLAT"}`
@@ -184,3 +185,10 @@ or if you wish to re-enable
       `# quick # techdebt`
 
 Where `<term>` is some text contained in the ticket you are looking for## Documentation with Configuration examples from above
+
+
+#### Quering Tickets with JQL
+> hubot jira query `<jql>`
+
+Where `<jql>` is a valid JQL query
+"""

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -128,7 +128,10 @@ class Config
     regex: /(?:\s+|^)#\S+/g
 
   @search:
-    regex: /(?:j|jira) (?:s|search|find|query) (.+)/
+    regex: /(?:j|jira) (?:s|search|find) (.+)/
+
+  @query:
+    regex: /(?:j|jira) (?:q|query) (.+)/
 
   @help:
     regex: /(?:help jira|jira help)(?: (.*))?/

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -3,6 +3,7 @@
 #   HUBOT_GITHUB_TOKEN - Github Application Token
 #   HUBOT_JIRA_DUPLICATE_DETECTION - Set to true if wish to detect duplicates when creating new issues
 #   HUBOT_JIRA_GITHUB_DISABLED - Set to true if you wish to disable github integration
+#   HUBOT_JIRA_MENTIONS_DISABLED - Set to true if you wish to disable posting tickets in response to mentions in normal messages
 #   HUBOT_JIRA_PASSWORD
 #   HUBOT_JIRA_PRIORITIES_MAP [{"name":"Blocker","id":"1"},{"name":"Critical","id":"2"},{"name":"Major","id":"3"},{"name":"Minor","id":"4"},{"name":"Trivial","id":"5"}]
 #   HUBOT_JIRA_PROJECTS_MAP  {"web":"WEB","android":"AN","ios":"IOS","platform":"PLAT"}
@@ -53,6 +54,7 @@ class Config
       url: process.env.HUBOT_JIRA_URL
       username: process.env.HUBOT_JIRA_USERNAME
       password: process.env.HUBOT_JIRA_PASSWORD
+      mentionsDisabled: !!process.env.HUBOT_JIRA_MENTIONS_DISABLED
       expand: "transitions"
       fields: ["issuetype", "status", "assignee", "reporter", "summary", "description", "labels", "project"]
       mentionRegex: /(?:\[~([\w._-]*)\])/i

--- a/src/help.coffee
+++ b/src/help.coffee
@@ -141,6 +141,13 @@ class Help
     Where `<term>` is some text contained in the ticket you are looking for
     """
 
+    query = """
+    *Querying Tickets using JQL*
+    > #{robot.name} jira query `<jql>`
+
+    Where `<jql>` is a valid JQL query
+    """
+
     if _(["report", "open", "file", "subtask", _(Config.maps.types).keys()]).chain().flatten().contains(topic).value()
       responses = [ opening, subtask ]
     else if _(["clone", "duplicate", "copy"]).contains topic
@@ -157,10 +164,12 @@ class Help
       responses = [ transition ]
     else if _(["search", "searching"]).contains topic
       responses = [ search ]
+    else if _(["query", "querying"]).contains topic
+      responses = [ query ]
     else if _(["watch", "watching", "notifications", "notify"]).contains topic
       responses = [ watch, notifications ]
     else
-      responses = [ overview, opening, subtask, clone, rank, comment, labels, assignment, transition, watch, notifications, search ]
+      responses = [ overview, opening, subtask, clone, rank, comment, labels, assignment, transition, watch, notifications, search, query ]
 
     return "\n#{responses.join '\n\n\n'}"
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -508,9 +508,10 @@ class JiraBot
 
       Utils.Stats.increment "command.jirabot.create"
 
-    #Mention ticket by url or key
-    @robot.listen @matchJiraTicket, (context) =>
-      @prepareResponseForJiraTickets context
-      Utils.Stats.increment "command.jirabot.mention.ticket"
+    unless Config.jira.mentionsDisabled
+      #Mention ticket by url or key
+      @robot.listen @matchJiraTicket, (context) =>
+        @prepareResponseForJiraTickets context
+        Utils.Stats.increment "command.jirabot.mention.ticket"
 
 module.exports = JiraBot

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -399,6 +399,22 @@ class JiraBot
         @robot.logger.error error.stack
       Utils.Stats.increment "command.jirabot.search"
 
+    #Query
+    @robot.respond Config.query.regex, (context) =>
+      context.finish()
+      [__, query] = context.match
+      Jira.Query.withQuery(query)
+      .then (results) =>
+        attachments = (ticket.toAttachment(no) for ticket in results.tickets)
+        @send context,
+          text: results.text
+          attachments: attachments
+        , no
+      .catch (error) =>
+        @send context, "Unable to execute query `#{query}` :sadpanda:"
+        @robot.logger.error error.stack
+      Utils.Stats.increment "command.jirabot.query"
+
     #Transition
     if Config.maps.transitions
       @robot.hear Config.transitions.regex, (context) =>

--- a/src/jira/index.coffee
+++ b/src/jira/index.coffee
@@ -5,6 +5,7 @@ Create = require "./create"
 Labels = require "./labels"
 Rank = require "./rank"
 Search = require "./search"
+Query = require "./query"
 Ticket = require "./ticket"
 Transition = require "./transition"
 User = require "./user"
@@ -19,6 +20,7 @@ module.exports = {
   Labels
   Rank
   Search
+  Query
   Ticket
   Transition
   User

--- a/src/jira/query.coffee
+++ b/src/jira/query.coffee
@@ -1,0 +1,28 @@
+Config = require "../config"
+Ticket = require "./ticket"
+Utils = require "../utils"
+
+class Query
+
+  @withQuery: (jql, max=50) ->
+    noResults = "No results for #{jql}"
+    found = "Found <#{Config.jira.url}/secure/IssueNavigator.jspa?jqlQuery=__JQL__&runQuery=true|__xx__ issues>"
+    found.replace "__JQL__", encodeURIComponent jql
+
+    Utils.fetch "#{Config.jira.url}/rest/api/2/search",
+      method: "POST"
+      body: JSON.stringify
+        jql: jql
+        startAt: 0
+        maxResults: max
+        fields: Config.jira.fields
+    .then (json) ->
+      if json.issues.length > 0
+        text = found.replace("__xx__", json.total).replace "__JQL__", encodeURIComponent jql
+      else
+        text = noResults
+
+      text: text
+      tickets: (new Ticket issue for issue in json.issues)
+
+module.exports = Query


### PR DESCRIPTION
Adding a `query` keyword to allow direct JQL queries, like so:

`hubot jira query statusCategory!=Done AND cf[10003]=PROJ-696`

The main use is in combination with `hubot-alias` to have a quick keyword translate into a complex query.

I based the implementation on the `search` keyword, using the `query` alias original associated with search.

In addition, I also added an option to disabled responses to ticket mentions.